### PR TITLE
fix: Compile with template-haskell >2.17.0.0

### DIFF
--- a/dtypes.cabal
+++ b/dtypes.cabal
@@ -36,7 +36,7 @@ library
     DTypes.Internal.TH.Helpers
   build-depends:
     base >= 4.7 && < 5,
-    template-haskell,
+    template-haskell > 2.17.0.0,
     transformers >= 0.3 && < 0.6,
     safe
   default-language: Haskell2010
@@ -49,7 +49,7 @@ test-suite dtypes-th
   build-depends:
     base,
     dtypes,
-    template-haskell,
+    template-haskell > 2.17.0.0,
     HTF,
     safe,
     transformers

--- a/src/DTypes/Internal/TH/Helpers.hs
+++ b/src/DTypes/Internal/TH/Helpers.hs
@@ -36,11 +36,11 @@ liftAppEs x args =
     firstArg:nextArgs -> apAppEs [e| $x <$> $firstArg |] nextArgs
 
 -- | Extract the name from a TyVarBndr.
-nameFromTyVarBndr :: TyVarBndr -> Name
+nameFromTyVarBndr :: TyVarBndr a -> Name
 nameFromTyVarBndr bndr =
   case bndr of
-    PlainTV name -> name
-    KindedTV name _kind -> name
+    PlainTV name _ -> name
+    KindedTV name _ _kind -> name
 
 -- | Apply arguments to a type constructor.
 conAppsT :: Name -> [Type] -> Type

--- a/src/DTypes/TH.hs
+++ b/src/DTypes/TH.hs
@@ -96,7 +96,7 @@ makeDTypeForDec dec =
       functorTyVarName <- newName "f"
       let kindArrow from to = arrowK `appK` from `appK` to
           starToStarKind = starK `kindArrow` starK
-          functorTyVarBndr = KindedTV functorTyVarName starToStarKind
+          functorTyVarBndr = KindedTV functorTyVarName () starToStarKind
       return (functorTyVarName, functorTyVarBndr)
 
 makeFConForCon :: Name -> Con -> ConQ
@@ -149,7 +149,7 @@ getSimpleConstrInfo con =
 data SimpleTypeInfo
   = SimpleTypeInfo
   { stdi_typeName :: Name
-  , stdi_typeArgs :: [TyVarBndr]
+  , stdi_typeArgs :: [TyVarBndrUnit]
   , stdi_constrs :: [SimpleConstrInfo]
   } deriving (Show)
 


### PR DESCRIPTION
Didn’t make the effort to keep it compatible with the old version, I think it’s GHC >9.0 now?

Feel free to adjust in case you ever want to merge this :P

We are using the lib for some experimental config management, but are probably gonna replace it soon in favor of a different approach.